### PR TITLE
forward maxBatchSize option to dataloader

### DIFF
--- a/src/BatchedGraphQLClient.ts
+++ b/src/BatchedGraphQLClient.ts
@@ -20,9 +20,18 @@ export class BatchedGraphQLClient {
     if (options && typeof options.cacheResults !== 'undefined') {
       delete options.cacheResults
     }
+    
+    const maxBatchSize =
+      options && typeof options.maxBatchSize !== 'undefined'
+        ? options.maxBatchSize
+        : null
+
+    if (options && typeof options.maxBatchSize !== 'undefined') {
+      delete options.maxBatchSize
+    }
 
     this.options = options || {}
-    this.dataloader = new DataLoader(this.load, { cache })
+    this.dataloader = new DataLoader(this.load, { cache, maxBatchSize })
   }
 
   async request<T extends any>(


### PR DESCRIPTION
In order to adjust the size of the request we want to forward the `maxBatchSize` option (see https://github.com/graphql/dataloader#api) to the `DataLoader`. Currently only `cache` is passed.

With this PR `maxBatchSize` is forwarded as well.